### PR TITLE
Warn about duplicate records during import and creation

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
@@ -21,6 +21,10 @@ import { computeOptimisticCreateRecordBaseRecordInput } from '@/object-record/ut
 import { computeOptimisticRecordFromInput } from '@/object-record/utils/computeOptimisticRecordFromInput';
 import { getCreateOneRecordMutationResponseField } from '@/object-record/utils/getCreateOneRecordMutationResponseField';
 import { sanitizeRecordInput } from '@/object-record/utils/sanitizeRecordInput';
+import { useFindDuplicateRecordsByDataQuery } from '@/object-record/hooks/useFindDuplicateRecordsByDataQuery';
+import { getFindDuplicateRecordsQueryResponseField } from '@/object-record/utils/getFindDuplicateRecordsQueryResponseField';
+import { SnackBarVariant } from '@/ui/feedback/snack-bar-manager/components/SnackBar';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -68,6 +72,10 @@ export const useCreateOneRecord = <
   const { refetchAggregateQueries } = useRefetchAggregateQueries({
     objectMetadataNamePlural: objectMetadataItem.namePlural,
   });
+  const { enqueueSnackBar } = useSnackBar();
+  const { findDuplicateRecordsByDataQuery } = useFindDuplicateRecordsByDataQuery({
+    objectNameSingular,
+  });
 
   const createOneRecord = async (recordInput: Partial<CreatedObjectRecord>) => {
     setLoading(true);
@@ -81,6 +89,28 @@ export const useCreateOneRecord = <
       }),
       id: idForCreation,
     };
+
+    try {
+      const duplicateResult = await apolloClient.query({
+        query: findDuplicateRecordsByDataQuery,
+        variables: { data: [sanitizedInput] },
+        fetchPolicy: 'no-cache',
+      });
+
+      const duplicatesConnections = duplicateResult.data[
+        getFindDuplicateRecordsQueryResponseField(objectMetadataItem.nameSingular)
+      ];
+
+      const duplicatesCount = duplicatesConnections?.[0]?.edges?.length ?? 0;
+
+      if (duplicatesCount > 0) {
+        enqueueSnackBar(`Possible duplicate detected`, {
+          variant: SnackBarVariant.Warning,
+        });
+      }
+    } catch (e) {
+      // ignore duplicate check errors
+    }
 
     const optimisticRecordInput = computeOptimisticRecordFromInput({
       cache: apolloClient.cache,

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicateRecordsByData.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicateRecordsByData.ts
@@ -1,0 +1,86 @@
+import { useQuery } from '@apollo/client';
+import { useMemo } from 'react';
+
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { ObjectMetadataItemIdentifier } from '@/object-metadata/types/ObjectMetadataItemIdentifier';
+import { getRecordsFromRecordConnection } from '@/object-record/cache/utils/getRecordsFromRecordConnection';
+import { RecordGqlConnection } from '@/object-record/graphql/types/RecordGqlConnection';
+import { RecordGqlOperationFindDuplicatesResult } from '@/object-record/graphql/types/RecordGqlOperationFindDuplicatesResults';
+import { useFindDuplicateRecordsByDataQuery } from '@/object-record/hooks/useFindDuplicateRecordsByDataQuery';
+import { ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { getFindDuplicateRecordsQueryResponseField } from '@/object-record/utils/getFindDuplicateRecordsQueryResponseField';
+import { SnackBarVariant } from '@/ui/feedback/snack-bar-manager/components/SnackBar';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import { logError } from '~/utils/logError';
+
+export const useFindDuplicateRecordsByData = <T extends ObjectRecord = ObjectRecord>({
+  objectRecords = [],
+  objectNameSingular,
+  onCompleted,
+  skip,
+}: ObjectMetadataItemIdentifier & {
+  objectRecords: Partial<T>[] | undefined;
+  onCompleted?: (data: RecordGqlConnection[]) => void;
+  skip?: boolean;
+}) => {
+  const findDuplicateQueryStateIdentifier = objectNameSingular;
+
+  const { objectMetadataItem } = useObjectMetadataItem({
+    objectNameSingular,
+  });
+
+  const { findDuplicateRecordsByDataQuery } = useFindDuplicateRecordsByDataQuery({
+    objectNameSingular,
+  });
+
+  const { enqueueSnackBar } = useSnackBar();
+
+  const queryResponseField = getFindDuplicateRecordsQueryResponseField(
+    objectMetadataItem.nameSingular,
+  );
+
+  const { data, loading, error } =
+    useQuery<RecordGqlOperationFindDuplicatesResult>(
+      findDuplicateRecordsByDataQuery,
+      {
+        skip: !!skip,
+        variables: {
+          data: objectRecords,
+        },
+        onCompleted: (data) => {
+          onCompleted?.(data[queryResponseField]);
+        },
+        onError: (error) => {
+          logError(
+            `useFindDuplicateRecordsByData for "${objectMetadataItem.nameSingular}" error : ` +
+              error,
+          );
+          enqueueSnackBar(`Error finding duplicates:", ${error.message}`, {
+            variant: SnackBarVariant.Error,
+          });
+        },
+      },
+    );
+
+  const objectResults = data?.[queryResponseField];
+
+  const results = useMemo(
+    () =>
+      objectResults?.map((result: RecordGqlConnection) => {
+        return result
+          ? (getRecordsFromRecordConnection({
+              recordConnection: result,
+            }) as T[])
+          : [];
+      }),
+    [objectResults],
+  );
+
+  return {
+    objectMetadataItem,
+    results,
+    loading,
+    error,
+    queryStateIdentifier: findDuplicateQueryStateIdentifier,
+  };
+};

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicateRecordsByDataQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicateRecordsByDataQuery.ts
@@ -1,0 +1,50 @@
+import gql from 'graphql-tag';
+import { useRecoilValue } from 'recoil';
+
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { isAggregationEnabled } from '@/object-metadata/utils/isAggregationEnabled';
+import { mapObjectMetadataToGraphQLQuery } from '@/object-metadata/utils/mapObjectMetadataToGraphQLQuery';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
+import { getFindDuplicateRecordsQueryResponseField } from '@/object-record/utils/getFindDuplicateRecordsQueryResponseField';
+import { capitalize } from 'twenty-shared/utils';
+
+export const useFindDuplicateRecordsByDataQuery = ({
+  objectNameSingular,
+}: {
+  objectNameSingular: string;
+}) => {
+  const { objectMetadataItem } = useObjectMetadataItem({
+    objectNameSingular,
+  });
+
+  const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
+
+  const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
+
+  const capitalizedObjectName = capitalize(objectMetadataItem.nameSingular);
+
+  const findDuplicateRecordsByDataQuery = gql`
+    query FindDuplicate${capitalizedObjectName}FromData($data: [${capitalizedObjectName}CreateInput!]!) {
+      ${getFindDuplicateRecordsQueryResponseField(objectMetadataItem.nameSingular)}(data: $data) {
+        edges {
+          node ${mapObjectMetadataToGraphQLQuery({
+            objectMetadataItems,
+            objectMetadataItem,
+            objectPermissionsByObjectMetadataId,
+          })}
+          cursor
+        }
+        pageInfo {
+          ${isAggregationEnabled(objectMetadataItem) ? 'hasNextPage' : ''}
+          startCursor
+          endCursor
+        }
+      }
+    }
+  `;
+
+  return {
+    findDuplicateRecordsByDataQuery,
+  };
+};

--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/hooks/useOpenObjectRecordsSpreadsheetImportDialog.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/hooks/useOpenObjectRecordsSpreadsheetImportDialog.ts
@@ -1,5 +1,7 @@
+import { useApolloClient } from '@apollo/client';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useBatchCreateManyRecords } from '@/object-record/hooks/useBatchCreateManyRecords';
+import { useFindDuplicateRecordsByDataQuery } from '@/object-record/hooks/useFindDuplicateRecordsByDataQuery';
 import { useBuildAvailableFieldsForImport } from '@/object-record/spreadsheet-import/hooks/useBuildAvailableFieldsForImport';
 import { buildRecordFromImportedStructuredRow } from '@/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow';
 import { spreadsheetImportFilterAvailableFieldMetadataItems } from '@/object-record/spreadsheet-import/utils/spreadsheetImportFilterAvailableFieldMetadataItems.ts';
@@ -10,6 +12,7 @@ import { spreadsheetImportCreatedRecordsProgressState } from '@/spreadsheet-impo
 import { SpreadsheetImportDialogOptions } from '@/spreadsheet-import/types';
 import { SnackBarVariant } from '@/ui/feedback/snack-bar-manager/components/SnackBar';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import { getFindDuplicateRecordsQueryResponseField } from '@/object-record/utils/getFindDuplicateRecordsQueryResponseField';
 import { useSetRecoilState } from 'recoil';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
@@ -37,6 +40,10 @@ export const useOpenObjectRecordsSpreadsheetImportDialog = (
   });
 
   const { buildAvailableFieldsForImport } = useBuildAvailableFieldsForImport();
+  const apolloClient = useApolloClient();
+  const { findDuplicateRecordsByDataQuery } = useFindDuplicateRecordsByDataQuery({
+    objectNameSingular,
+  });
 
   const openObjectRecordsSpreadsheetImportDialog = (
     options?: Omit<
@@ -74,6 +81,28 @@ export const useOpenObjectRecordsSpreadsheetImportDialog = (
         });
 
         try {
+          const duplicateResult = await apolloClient.query({
+            query: findDuplicateRecordsByDataQuery,
+            variables: { data: createInputs },
+            fetchPolicy: 'no-cache',
+          });
+
+          const duplicatesConnections = duplicateResult.data[
+            getFindDuplicateRecordsQueryResponseField(objectMetadataItem.nameSingular)
+          ];
+
+          const duplicatesCount = duplicatesConnections?.reduce(
+            (acc: number, conn: any) => acc + (conn.edges?.length ?? 0),
+            0,
+          );
+
+          if (duplicatesCount > 0) {
+            enqueueSnackBar(
+              `${duplicatesCount} possible duplicates detected`,
+              { variant: SnackBarVariant.Warning },
+            );
+          }
+
           await batchCreateManyRecords({
             recordsToCreate: createInputs,
             upsert: true,


### PR DESCRIPTION
## Summary
- add GraphQL query helper to find duplicates using data
- expose hook to fetch duplicates by data
- warn on possible duplicates when importing spreadsheet data
- warn on possible duplicates when creating a record

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d56ad37608329b90c3e3deb8500b3